### PR TITLE
Change File.exists? to File.exist? for Ruby 3.2

### DIFF
--- a/bin/dokaz
+++ b/bin/dokaz
@@ -5,7 +5,7 @@ require 'slop'
 $:.unshift 'lib'
 require 'dokaz'
 
-if File.exists?('.dokaz')
+if File.exist?('.dokaz')
   ARGV.push(*File.read('.dokaz').split(/\s+/m))
 end
 


### PR DESCRIPTION
Ruby 3.2 removed the `File.exists?` alias method.

---

Also, @zverok I see your location listed as Kharkiv. Just wanted to send some ❤️ 